### PR TITLE
Move backdrop shadow inside of dialog container to improve SR Exp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # myuw-feedback versions
 
+## 1.0.3
+
+* Move backdrop shadow inside of dialog container to improve Screen Reader navigation across the browsers
 ## 1.0.2
 
 # Fixed

--- a/index.html
+++ b/index.html
@@ -41,42 +41,38 @@
     text-decoration: none;
   }
   #dialog-actions {
-    margin-top: 2.8em;
+    margin-top: 1.5em;
+    text-align: right;
   }
+
   .dialog-action {
-    color: rgba(255,255,255,0.87);
-    background-color: rgb(4,121,168);
-    padding: 10px;
-    text-decoration: none;
-    display: inline-block;
-    position: relative;
-    cursor: pointer;
-    min-height: 36px;
-    min-width: 88px;
-    line-height: 36px;
-    text-align: center;
-    border-radius: 2px;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    border: 0;
-    padding: 0 10px;
-    white-space: nowrap;
-    text-transform: uppercase;
-    font-weight: 500;
-    font-size: 14px;
-    font-style: inherit;
-    font-variant: inherit;
-    font-family: inherit;
-    text-decoration: none;
-    transition: box-shadow .4s cubic-bezier(.25,.8,.25,1),background-color .4s cubic-bezier(.25,.8,.25,1);
-  }
+  color: #fff;
+  background-color: rgb(4,121,168);
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  line-height: 36px;
+  text-align: center;
+  border-radius: 3px;
+  border: none;
+  padding: 4px 10px;
+  font-weight: 600;
+  font-family: inherit;
+  text-decoration: none;
+  transition: box-shadow .4s cubic-bezier(.25,.8,.25,1),background-color .4s cubic-bezier(.25,.8,.25,1);
+}
+
+.dialog-action:hover,
+.dialog-action:focus {
+background-color: rgb(1 98 138);
+}
+
 </style>
 
 <!-- Web component polyfill loader -->
 <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.1.3/webcomponents-loader.js"></script>
 <!-- MyUW web components -->
 <script type="module">
-  import "https://cdn.my.wisc.edu/@myuw-web-components/myuw-app-styles@latest/myuw-app-styles.min.mjs";
   import "https://unpkg.com/@myuw-web-components/myuw-app-bar@^1?module";
   import "./dist/myuw-feedback.mjs";
   window.setCustomPosition = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-feedback",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-feedback",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "module": "dist/myuw-feedback.min.mjs",
   "browser": "dist/myuw-feedback.min.js",

--- a/src/myuw-feedback.html
+++ b/src/myuw-feedback.html
@@ -54,6 +54,9 @@
 
   #myuw-feedback__dialog {
     display: none;
+  }
+
+  .myuw-feedback__dialog-window {
     max-width: 80%;
     min-width: 300px;
     height: auto;
@@ -67,15 +70,12 @@
     margin-right: auto;
     border-radius: 5px;
     font-family: var(--myuw-font, 'Roboto', Arial, sans-serif);
-    opacity: 0;
-    position: absolute;
-    float: left;
-    top: 0;
-    right: -1000px;
+    position: relative;
     -webkit-transition: all .4s cubic-bezier(.25, .8, .25, 1);
     transition: all .4s cubic-bezier(.25, .8, .25, 1);
-    z-index: 101;
+    z-index: 110;
   }
+
 
   #myuw-feedback__heading {
     display: flex;
@@ -91,7 +91,7 @@
     letter-spacing: 0.03px;
   }
 
-  #myuw-feedback__content {
+  #myuw-feedback__main-content {
     font-weight: 400;
     font-size: 16px;
     color: rgba(0, 0, 0, .8);
@@ -210,18 +210,20 @@
 </button>
 
 <div id="myuw-feedback__dialog" role="dialog" aria-labelledby="myuw-feedback__title" aria-modal="true">
-  <div id="myuw-feedback__heading">
-    <h1 id="myuw-feedback__title"></h1>
-    <button id="myuw-feedback__close-button" aria-label="Close feedback dialog">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-        <path
-          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-        <path d="M0 0h24v24H0z" fill="none" />
-      </svg>
-    </button>
+  <div class="myuw-feedback__dialog-window">
+    <div id="myuw-feedback__heading">
+      <h1 id="myuw-feedback__title"></h1>
+      <button id="myuw-feedback__close-button" aria-label="Close feedback dialog">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path
+            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+          <path d="M0 0h24v24H0z" fill="none" />
+        </svg>
+      </button>
+    </div>
+    <div id="myuw-feedback__main-content">
+      <slot name="myuw-feedback-content"></slot>
+    </div>
   </div>
-  <div id="myuw-feedback__content">
-    <slot name="myuw-feedback-content"></slot>
-  </div>
+  <div id="myuw-feedback__shadow"></div>
 </div>
-<div id="myuw-feedback__shadow"></div>


### PR DESCRIPTION
2022-02-14

- Move backdrop shadow inside of dialog container to improve Screen Reader navigation across the browsers
- No visual changes
- Applying the same changes as to the [Help Component](https://github.com/myuw-web-components/myuw-help/pull/34)
